### PR TITLE
bccomp with scale parameter

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -61,7 +61,7 @@ final class Money
     {
         self::assertNumeric($arguments[0]);
 
-        return new self((string)$arguments[0], Currency::fromCode($method));
+        return new self((string) $arguments[0], Currency::fromCode($method));
     }
 
     /**
@@ -76,7 +76,7 @@ final class Money
     {
         self::assertNumeric($amount);
 
-        return new self((string)$amount, $currency);
+        return new self((string) $amount, $currency);
     }
 
     /**
@@ -157,7 +157,7 @@ final class Money
     {
         self::assertNumeric($multiplier);
 
-        $amount = bcmul($this->amount, (string)$multiplier, self::SCALE);
+        $amount = bcmul($this->amount, (string) $multiplier, self::SCALE);
 
         return $this->newInstance($amount);
     }
@@ -174,7 +174,7 @@ final class Money
     {
         self::assertNumeric($divisor);
 
-        $amount = bcdiv($this->amount, (string)$divisor, self::SCALE);
+        $amount = bcdiv($this->amount, (string) $divisor, self::SCALE);
 
         return $this->newInstance($amount);
     }
@@ -210,7 +210,7 @@ final class Money
     {
         self::assertNumeric($conversionRate);
 
-        $amount = bcmul($this->amount, (string)$conversionRate, self::SCALE);
+        $amount = bcmul($this->amount, (string) $conversionRate, self::SCALE);
 
         return new Money($amount, $targetCurrency);
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -61,7 +61,7 @@ final class Money
     {
         self::assertNumeric($arguments[0]);
 
-        return new self((string) $arguments[0], Currency::fromCode($method));
+        return new self((string)$arguments[0], Currency::fromCode($method));
     }
 
     /**
@@ -76,7 +76,7 @@ final class Money
     {
         self::assertNumeric($amount);
 
-        return new self((string) $amount, $currency);
+        return new self((string)$amount, $currency);
     }
 
     /**
@@ -157,7 +157,7 @@ final class Money
     {
         self::assertNumeric($multiplier);
 
-        $amount = bcmul($this->amount, (string) $multiplier, self::SCALE);
+        $amount = bcmul($this->amount, (string)$multiplier, self::SCALE);
 
         return $this->newInstance($amount);
     }
@@ -174,7 +174,7 @@ final class Money
     {
         self::assertNumeric($divisor);
 
-        $amount = bcdiv($this->amount, (string) $divisor, self::SCALE);
+        $amount = bcdiv($this->amount, (string)$divisor, self::SCALE);
 
         return $this->newInstance($amount);
     }
@@ -191,7 +191,7 @@ final class Money
         if (!is_int($scale)) {
             throw new InvalidArgumentException('Scale is not an integer');
         }
-        $add = '0.'. str_repeat('0', $scale) . '5';
+        $add = '0.' . str_repeat('0', $scale) . '5';
         $newAmount = bcadd($this->amount, $add, $scale);
 
         return $this->newInstance($newAmount);
@@ -210,7 +210,7 @@ final class Money
     {
         self::assertNumeric($conversionRate);
 
-        $amount = bcmul($this->amount, (string) $conversionRate, self::SCALE);
+        $amount = bcmul($this->amount, (string)$conversionRate, self::SCALE);
 
         return new Money($amount, $targetCurrency);
     }
@@ -258,7 +258,7 @@ final class Money
      */
     public function isLessThan(Money $other)
     {
-        return  $this->compareTo($other) === -1;
+        return $this->compareTo($other) === -1;
     }
 
     /**
@@ -326,7 +326,7 @@ final class Money
     {
         $this->assertSameCurrencyAs($other);
 
-        return bccomp($this->amount, $other->amount);
+        return bccomp($this->amount, $other->amount, self::SCALE);
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -241,6 +241,8 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $euro3 = Money::fromAmount('100', Currency::fromCode('EUR'));
         $euro4 = Money::fromAmount('0', Currency::fromCode('EUR'));
         $euro5 = Money::fromAmount('-100', Currency::fromCode('EUR'));
+        $euro6 = Money::fromAmount('1.1111', Currency::fromCode('EUR'));
+        $euro7 = Money::fromAmount('1.2222', Currency::fromCode('EUR'));
 
         $this->assertTrue($euro2->isGreaterThan($euro1));
         $this->assertFalse($euro1->isGreaterThan($euro2));
@@ -248,6 +250,7 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($euro2->isLessThan($euro1));
         $this->assertTrue($euro1->equals($euro3));
         $this->assertFalse($euro1->equals($euro2));
+        $this->assertFalse($euro6->equals($euro7));
 
         $this->assertTrue($euro1->isGreaterThanOrEqualTo($euro3));
         $this->assertTrue($euro1->isLessThanOrEqualTo($euro3));
@@ -257,6 +260,8 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($euro4->isLessThanOrEqualTo($euro1));
         $this->assertTrue($euro4->isGreaterThanOrEqualTo($euro5));
+
+        $this->assertTrue($euro6->isLessThanOrEqualTo($euro7));
     }
 
     /**


### PR DESCRIPTION
Hi,

I think it makes no sense that all the operations are made with the SCALE parameter, and then when these numbers are compared it is done without the same SCALE. This leads to invalid results, since the numbers are compared ignoring their decimal part.

According to the official PHP documentation (http://php.net/manual/en/function.bccomp.php):

```
scale
The optional scale parameter is used to set the number of digits after the decimal place which will be used in the comparison.
```

With this fix, bccomp will know that for instance 1.22 is greater than 1.11.
