### PR TITLE
Throw exception in case divisor is zero

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -32,7 +32,6 @@ final class Money
      */
     protected $currency;
 
-
     /**
      * @param string $amount Amount, expressed as a string (eg '10.00')
      * @param Currency $currency
@@ -169,10 +168,14 @@ final class Money
      * @param numeric $divisor
      *
      * @return Money
+     * @throws InvalidArgumentException In case divisor is zero.
      */
     public function divideBy($divisor)
     {
         self::assertNumeric($divisor);
+        if (0 === bccomp((string) $divisor, '', self::SCALE)) {
+            throw new InvalidArgumentException('Divisor cannot be 0.');
+        }
 
         $amount = bcdiv($this->amount, (string) $divisor, self::SCALE);
 

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -177,11 +177,40 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $money = Money::fromAmount('30', Currency::fromCode('EUR'));
         $expected1 = Money::fromAmount('15', Currency::fromCode('EUR'));
         $expected2 = Money::fromAmount('3.33333333333', Currency::fromCode('EUR'));
+        $expected3 = Money::fromAmount('-3', Currency::fromCode('EUR'));
 
         $this->assertTrue($money->divideBy(2)->equals($expected1));
         $this->assertTrue($money->divideBy(9)->equals($expected2));
+        $this->assertTrue($money->divideBy(-10)->equals($expected3));
 
         $this->assertNotSame($money, $money->divideBy(2));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testDivisorIsNumericZero()
+    {
+        $money = Money::fromAmount('30', Currency::fromCode('EUR'));
+        $money->divideBy(0)->amount();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testDivisorIsFloatZero()
+    {
+        $money = Money::fromAmount('30', Currency::fromCode('EUR'));
+        $money->divideBy(0.0)->amount();
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testDivisorIsStringZero()
+    {
+        $money = Money::fromAmount('30', Currency::fromCode('EUR'));
+        $money->divideBy('0')->amount();
     }
 
     /**


### PR DESCRIPTION
Hi!

This PR is to throw an InvalidArgumentException instead of a PHP Warning:

```
Warning: bcdiv(): Division by zero 
```

when divisor is 0, in divisionBy method.
