### PR TITLE
fix(Money): fix issue #5

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -194,8 +194,7 @@ final class Money
         if (!is_int($scale)) {
             throw new InvalidArgumentException('Scale is not an integer');
         }
-        $add = '0.' . str_repeat('0', $scale) . '5';
-        $newAmount = bcadd($this->amount, $add, $scale);
+        $newAmount = sprintf('%.'.$scale.'f', $this->amount());
 
         return $this->newInstance($newAmount);
     }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -244,6 +244,26 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::round
+     */
+    public function testRoundWithNegativeAmountNoRounding()
+    {
+        $money = Money::fromAmount('-3.9813', Currency::fromCode('EUR'));
+        $expect = Money::fromAmount('-3.98', Currency::fromCode('EUR'));
+        $this->assertEquals($expect, $money->round(2));
+    }
+
+    /**
+     * @covers ::round
+     */
+    public function testRoundWithNegativeAmountRounding()
+    {
+        $money = Money::fromAmount('-3.9863', Currency::fromCode('EUR'));
+        $expect = Money::fromAmount('-3.99', Currency::fromCode('EUR'));
+        $this->assertEquals($expect, $money->round(2));
+    }
+
+    /**
      * @covers ::convertTo
      */
     public function convertTo()


### PR DESCRIPTION
This is a fix for _Money does not round negative numbers correctly_ #5 

To solve this issue I use `sprintf` in `Money::round()`

