### PR TITLE
remove useless decimal zeros

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -38,11 +38,20 @@ final class Money
      *
      * @throws InvalidArgumentException If amount is not a numeric string value
      */
-    private function __construct($amount, Currency $currency)
-    {
-        $this->amount = $amount;
-        $this->currency = $currency;
-    }
+     private function __construct($amount, Currency $currency)
+     {
+         $this->setAmount($amount);
+         $this->currency = $currency;
+     }
+
+     /**
+      * @param string $amount
+      */
+     private function setAmount($amount)
+     {
+         $hasDecimals = (bool) preg_match('/\./', $amount);
+         $this->amount = ($hasDecimals) ? rtrim($amount, "0") : $amount;
+     }
 
     /**
      * Convenience factory method for a Money object

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -357,4 +357,13 @@ final class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Money::EUR(1)->hasSameCurrencyAs(Money::EUR(1)));
         $this->assertFalse(Money::EUR(1)->hasSameCurrencyAs(Money::USD(1)));
     }
+
+    public function testRemoveUselessZeros()
+    {
+        $money = Money::fromAmount('100.00', Currency::fromCode('EUR'));
+        $this->assertEquals('100', $money->amount());
+
+        $secondMoney = Money::fromAmount('100.7200', Currency::fromCode('EUR'));
+        $this->assertEquals('100.72', $secondMoney->amount());
+    }
 }


### PR DESCRIPTION
As the default scale is 4, doing bc operations with, ie, 2 decimals, the results will have 2 extra zero decimals.
IE:
```
$money = Money::fromAmount('9.25', Currency::fromCode('EUR'));
$secondMoney = Money::fromAmount('10', Currency::fromCode('EUR'));

echo $money->add($secondMoney)->amount();
```
the above will print `19.2500` instead of `19.25`. We are fixing this on new instances in this PR